### PR TITLE
Add useSchema config option for UnboundID

### DIFF
--- a/server-api/src/main/java/com/btmatthews/maven/plugins/ldap/AbstractLDAPServer.java
+++ b/server-api/src/main/java/com/btmatthews/maven/plugins/ldap/AbstractLDAPServer.java
@@ -57,6 +57,10 @@ public abstract class AbstractLDAPServer extends AbstractServer implements LDAPS
      * The TCP port on which the server is listening for LDAP traffic.
      */
     private int serverPort;
+    /**
+     * The flag indicating if entries should be validated against schema.
+     */
+    private boolean useSchema;
 
     /**
      * Used to configure the root DN of the LDAP directory, the working directory used by the directory service to
@@ -103,6 +107,11 @@ public abstract class AbstractLDAPServer extends AbstractServer implements LDAPS
             if (value instanceof Integer) {
                 serverPort = (Integer) value;
                 logger.logInfo("Configured TCP port for directory server: " + serverPort);
+            }
+        } else if (USE_SCHEMA.equals(name)) {
+            if (value instanceof Integer) {
+                useSchema = (Boolean) value;
+                logger.logInfo("Validate against schema: " + useSchema);
             }
         }
     }
@@ -168,5 +177,14 @@ public abstract class AbstractLDAPServer extends AbstractServer implements LDAPS
      */
     public final int getServerPort() {
         return serverPort;
+    }
+    
+    /**
+     * Get the flag indicating if entries will be validated against schema.
+     *
+     * @return The port.
+     */
+    public final boolean getUseSchema() {
+        return useSchema;
     }
 }

--- a/server-api/src/main/java/com/btmatthews/maven/plugins/ldap/LDAPServer.java
+++ b/server-api/src/main/java/com/btmatthews/maven/plugins/ldap/LDAPServer.java
@@ -56,6 +56,10 @@ public interface LDAPServer extends Server {
      * The name of the parameter that specifies the port on which the LDAP service will listen for traffic.
      */
     String LDAP_PORT = "ldapPort";
+    /**
+     * The name of the parameter that specifies whether the server should validate entries against schema.
+     */
+    String USE_SCHEMA = "useSchema";
 
     /**
      * Get the configured directory root.
@@ -98,4 +102,11 @@ public interface LDAPServer extends Server {
      * @return The port.
      */
     int getServerPort();
+    
+    /**
+     * Get the flag indicating if entries will be validated against schema.
+     *
+     * @return The use schema flag.
+     */
+    boolean getUseSchema();
 }

--- a/server-unboundid/src/main/java/com/btmatthews/maven/plugins/ldap/unboundid/UnboundIDServer.java
+++ b/server-unboundid/src/main/java/com/btmatthews/maven/plugins/ldap/unboundid/UnboundIDServer.java
@@ -62,6 +62,9 @@ public final class UnboundIDServer extends AbstractLDAPServer {
             final InMemoryListenerConfig listenerConfig = InMemoryListenerConfig.createLDAPConfig("default", getServerPort());
             final InMemoryDirectoryServerConfig config = new InMemoryDirectoryServerConfig(new DN(getRoot()));
             config.setListenerConfigs(listenerConfig);
+            if( !getUseSchema()) {
+            	config.setSchema(null);
+            }
             if (getAuthDn() != null) {
                 config.addAdditionalBindCredentials(getAuthDn(), getPasswd());
             }

--- a/server-unboundid/src/test/java/com/btmatthews/maven/plugins/ldap/unboundid/TestUnboundIDServer.java
+++ b/server-unboundid/src/test/java/com/btmatthews/maven/plugins/ldap/unboundid/TestUnboundIDServer.java
@@ -49,6 +49,7 @@ public class TestUnboundIDServer {
         server.configure("authDn", "uid=admin,ou=system", logger);
         server.configure("passwd", "secret", logger);
         server.configure("ldapPort", port, logger);
+        server.configure("useSchema", false, logger);
         server.configure("ldifFile", new File("target/test-classes/com/btmatthews/maven/plugins/ldap/unboundid/initial.ldif"), logger);
         server.configure("workingDirectory", folder.newFolder(), logger);
         server.start(logger);

--- a/server-unboundid/src/test/resources/com/btmatthews/maven/plugins/ldap/unboundid/initial.ldif
+++ b/server-unboundid/src/test/resources/com/btmatthews/maven/plugins/ldap/unboundid/initial.ldif
@@ -40,3 +40,4 @@ givenName: Carl
 uid: ccarlson
 title: Worker
 objectclass: inetOrgPerson
+newattribute: test


### PR DESCRIPTION
Allows for disabling schema validation for UnboundID.

Useful for creating tests for LDAP servers that allow custom attributes (like Active Directory) without having to add those schemas to the test server. 